### PR TITLE
Allow FT commands to bypass escaping

### DIFF
--- a/NHapi20/NHapi.Base/Parser/Escape.cs
+++ b/NHapi20/NHapi.Base/Parser/Escape.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Specialized;
 using System.Collections;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Linq;
 
 namespace NHapi.Base.Parser
@@ -73,6 +74,10 @@ namespace NHapi.Base.Parser
             return ht;
         }
 
+        static Regex formattedTextSpaceCommand = new Regex(@"^\.sp(\+?\d+)?$", RegexOptions.Compiled);
+        static Regex formattedTextIndentCommand = new Regex(@"^\.in(\+|-)?\d+$", RegexOptions.Compiled);
+        static Regex formattedTextTemporaryIndentCommand = new Regex(@"^\.ti(\+|-)?\d+$", RegexOptions.Compiled);
+        static Regex formattedTextSkipCommand = new Regex(@"^\.sk(\+|-)?\d+$", RegexOptions.Compiled);
 
         /// <summary>
         /// Escape string
@@ -124,8 +129,19 @@ namespace NHapi.Base.Parser
                                 // FT escapes are multi-character sequences starting with '.'
                                 if (textAsChar[i + 1] == '.')
                                 {
-                                    encodeCharacter = false;
-                                    isEncodingSpecialCharacterSequence = true;
+                                    var potentialEscapeSequence = text.Substring(i + 1, nextEscapeChar - i - 1);
+                                    if (potentialEscapeSequence == ".br" ||
+                                        potentialEscapeSequence == ".fi" || 
+                                        potentialEscapeSequence == ".nf" ||
+                                        potentialEscapeSequence == ".ce" ||
+                                        formattedTextSpaceCommand.IsMatch(potentialEscapeSequence) ||
+                                        formattedTextIndentCommand.IsMatch(potentialEscapeSequence) ||
+                                        formattedTextTemporaryIndentCommand.IsMatch(potentialEscapeSequence) ||
+                                        formattedTextSkipCommand.IsMatch(potentialEscapeSequence))
+                                    {
+                                        encodeCharacter = false;
+                                        isEncodingSpecialCharacterSequence = true;
+                                    }
                                 }
                                 else if (_multiCharNonEscapeCharacterMapping[textAsChar[i + 1].ToString()] != null)
                                 {

--- a/NHapi20/NHapi.Base/Parser/Escape.cs
+++ b/NHapi20/NHapi.Base/Parser/Escape.cs
@@ -38,10 +38,8 @@ namespace NHapi.Base.Parser
     public class Escape
     {
         //This items are are to not be escaped when building the message
-        private static string[] NON_ESCAPE_CHARACTERS = new string[] { @"\.", @"\X", @"\Z", @"\C", @"\M", @"\H", @"\N", @"\S" };
         private static string[] SINGLE_CHAR_NON_ESCAPE_CHARACTERS = new string[] { @"H", @"N", @"S", @"T", @"R", @"F", @"E" };
         private static string[] MULTI_CHAR_NON_ESCAPE_CHARACTERS = new string[] { @"X", @"Z", @"C", @"M" };
-        private static Hashtable _nonEscapeCharacterMapping = new Hashtable();
         private static Hashtable _singleCharNonEscapeCharacterMapping = new Hashtable();
         private static Hashtable _multiCharNonEscapeCharacterMapping = new Hashtable();
         private static Hashtable variousEncChars = new Hashtable(5);
@@ -49,10 +47,6 @@ namespace NHapi.Base.Parser
 
         static Escape()
         {
-            foreach (string element in NON_ESCAPE_CHARACTERS)
-            {
-                _nonEscapeCharacterMapping.Add(element, element);
-            }
             foreach (string element in SINGLE_CHAR_NON_ESCAPE_CHARACTERS)
             {
                 _singleCharNonEscapeCharacterMapping.Add(element, element);
@@ -127,7 +121,13 @@ namespace NHapi.Base.Parser
                             }
                             else if (nextEscapeChar != -1)
                             {
-                                if (_multiCharNonEscapeCharacterMapping[textAsChar[i + 1].ToString()] != null)
+                                // FT escapes are multi-character sequences starting with '.'
+                                if (textAsChar[i + 1] == '.')
+                                {
+                                    encodeCharacter = false;
+                                    isEncodingSpecialCharacterSequence = true;
+                                }
+                                else if (_multiCharNonEscapeCharacterMapping[textAsChar[i + 1].ToString()] != null)
                                 {
                                     // Contains /#xxyyzz..nn/ from the main string.
                                     string potentialEscapeSequence = text.Substring(i, nextEscapeChar - i + 1);

--- a/NHapi20/NHapi.Base/Parser/Escape.cs
+++ b/NHapi20/NHapi.Base/Parser/Escape.cs
@@ -30,9 +30,7 @@ using System.Linq;
 namespace NHapi.Base.Parser
 {
     /// <summary> Handles "escaping" and "unescaping" of text according to the HL7 escape sequence rules
-    /// defined in section 2.10 of the standard (version 2.4).  Currently, escape sequences for 
-    /// multiple character sets are unsupported.  The highlighting, hexademical, and locally 
-    /// defined escape sequences are also unsupported.  
+    /// defined in section 2.10 of the standard (version 2.4).  The locally defined escape sequences are also unsupported.
     /// </summary>
     /// <author>  Bryan Tripp
     /// </author>
@@ -45,6 +43,11 @@ namespace NHapi.Base.Parser
         private static Hashtable _multiCharNonEscapeCharacterMapping = new Hashtable();
         private static Hashtable variousEncChars = new Hashtable(5);
         private static char[] HexDigits = new char[16] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+
+        private static Regex formattedTextSpaceCommand = new Regex(@"^\.sp(\+?\d+)?$", RegexOptions.Compiled);
+        private static Regex formattedTextIndentCommand = new Regex(@"^\.in(\+|-)?\d+$", RegexOptions.Compiled);
+        private static Regex formattedTextTemporaryIndentCommand = new Regex(@"^\.ti(\+|-)?\d+$", RegexOptions.Compiled);
+        private static Regex formattedTextSkipCommand = new Regex(@"^\.sk(\+|-)?\d+$", RegexOptions.Compiled);
 
         static Escape()
         {
@@ -73,11 +76,6 @@ namespace NHapi.Base.Parser
             }
             return ht;
         }
-
-        static Regex formattedTextSpaceCommand = new Regex(@"^\.sp(\+?\d+)?$", RegexOptions.Compiled);
-        static Regex formattedTextIndentCommand = new Regex(@"^\.in(\+|-)?\d+$", RegexOptions.Compiled);
-        static Regex formattedTextTemporaryIndentCommand = new Regex(@"^\.ti(\+|-)?\d+$", RegexOptions.Compiled);
-        static Regex formattedTextSkipCommand = new Regex(@"^\.sk(\+|-)?\d+$", RegexOptions.Compiled);
 
         /// <summary>
         /// Escape string

--- a/NHapi20/NHapi.Tests/EscapeTest.cs
+++ b/NHapi20/NHapi.Tests/EscapeTest.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NHapi.Base.Parser;
+using Xunit;
+
+namespace NHapi.Tests
+{
+	public class EscapeTest
+	{
+		[Theory]
+		[MemberData(nameof(testData))]
+		public void TestEscapes(string input, string expected)
+		{
+			var encodingChars = new EncodingCharacters('|', null);
+			var actual = Escape.escape(input, encodingChars);
+
+			Assert.Equal(expected, actual);
+		}
+
+		public static TheoryData<string, string> testData = new TheoryData<string, string>
+		{ 
+			// control characters should be escaped
+			{@"\", @"\E\"}, 
+			{@"|", @"\F\"}, 
+			{@"^", @"\S\"},
+			{@"&", @"\T\"},
+			{@"~", @"\R\"}, 
+
+			// command sequences should not be escaped
+			{@"\H\", @"\H\"},
+			{@"\N\", @"\N\"},
+			{@"\XAB\", @"\XAB\"},
+			{@"\CAB\", @"\CAB\"},
+			{@"\MAB\", @"\MAB\"},
+			{@"\ZAB\", @"\E\ZAB\E\"}, // .. but Z sequences are not supported
+
+			// FT commands should not be escaped
+			{@"\.br\", @"\.br\"},
+			{@"\.sp\", @"\.sp\"},
+			{@"\.sp+4\", @"\.sp+4\"},
+			{@"\.fi\", @"\.fi\"},
+			{@"\.nf\", @"\.nf\"},
+			{@"\.in+4\", @"\.in+4\"},
+			{@"\.ti-4\", @"\.ti-4\"},
+			{@"\.ce\", @"\.ce\"},
+
+			// unclosed escapes should be escaped
+			{@".br\", @".br\E\"},
+			{@".sp\", @".sp\E\"},
+			{@".sp+4\", @".sp+4\E\"},
+			{@".fi\", @".fi\E\"},
+			{@".nf\", @".nf\E\"},
+			{@".in+4\", @".in+4\E\"},
+			{@".ti-4\", @".ti-4\E\"},
+			{@".ce\", @".ce\E\"},
+
+			{@"\.br", @"\E\.br"},
+			{@"\.sp", @"\E\.sp"},
+			{@"\.sp+4", @"\E\.sp+4"},
+			{@"\.fi", @"\E\.fi"},
+			{@"\.nf", @"\E\.nf"},
+			{@"\.in+4", @"\E\.in+4"},
+			{@"\.ti-4", @"\E\.ti-4"},
+			{@"\.ce", @"\E\.ce"},
+		};
+	}
+}

--- a/NHapi20/NHapi.Tests/EscapeTest.cs
+++ b/NHapi20/NHapi.Tests/EscapeTest.cs
@@ -36,14 +36,28 @@ namespace NHapi.Tests
 			{@"\ZAB\", @"\E\ZAB\E\"}, // .. but Z sequences are not supported
 
 			// FT commands should not be escaped
-			{@"\.br\", @"\.br\"},
 			{@"\.sp\", @"\.sp\"},
+			{@"\.sp4\", @"\.sp4\"},
 			{@"\.sp+4\", @"\.sp+4\"},
+			{@"\.br\", @"\.br\"},
 			{@"\.fi\", @"\.fi\"},
 			{@"\.nf\", @"\.nf\"},
+			{@"\.in4\", @"\.in4\"},
 			{@"\.in+4\", @"\.in+4\"},
+			{@"\.in-4\", @"\.in-4\"},
+			{@"\.ti4\", @"\.ti4\"},
+			{@"\.ti+4\", @"\.ti+4\"},
 			{@"\.ti-4\", @"\.ti-4\"},
+			{@"\.sk8\", @"\.sk8\"},
+			{@"\.sk+8\", @"\.sk+8\"},
 			{@"\.ce\", @"\.ce\"},
+
+			// invalid FT commands should be escaped
+			{@"\.sp-4\", @"\E\.sp-4\E\"},
+			{@"\.spA\", @"\E\.spA\E\"},
+			{@"\.in+d\", @"\E\.in+d\E\"},
+			{@"\.ti-d\", @"\E\.ti-d\E\"},
+			{@"\.sk\", @"\E\.sk\E\"},
 
 			// unclosed escapes should be escaped
 			{@".br\", @".br\E\"},
@@ -54,7 +68,6 @@ namespace NHapi.Tests
 			{@".in+4\", @".in+4\E\"},
 			{@".ti-4\", @".ti-4\E\"},
 			{@".ce\", @".ce\E\"},
-
 			{@"\.br", @"\E\.br"},
 			{@"\.sp", @"\E\.sp"},
 			{@"\.sp+4", @"\E\.sp+4"},

--- a/NHapi20/NHapi.Tests/ParserTest.cs
+++ b/NHapi20/NHapi.Tests/ParserTest.cs
@@ -154,7 +154,7 @@ namespace NHapi.Tests
 			string[] fields = segs[2].Split('|');
 			string data = fields[5];
 
-			Assert.Equal(@"Th\T\is\E\.br\E\is\E\.br\E\A T\F\est\E\", data);
+			Assert.Equal(@"Th\T\is\.br\is\.br\A T\F\est\E\", data);
 		}
 
 		[Fact]


### PR DESCRIPTION
The comment in Escape.escape() suggests FT commands like \.br\ should not be escaped, but this is not the case. This makes it impossible to create a message containing an FT command:

```
observation.OBX.GetObservationValue(0).Data =
  new FT(message) { Value = @"line 1\.br\line 2" };
```

Expected OBX-5 = line 1\.br\line2
Actual OBX-5 = line 1\E\.br\E\line2